### PR TITLE
Remove debug logs from unlock feature

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -27,7 +27,6 @@ function Home() {
     };
     
     localStorage.setItem('mental-health-lms-progress', JSON.stringify(testProgress));
-    console.log('🔓 All modules unlocked for testing!');
     window.location.reload();
   };
 
@@ -35,8 +34,6 @@ function Home() {
   const handleVersionClick = () => {
     const newCount = clickCount + 1;
     setClickCount(newCount);
-    
-    console.log(`Click ${newCount}/5`); // Debug logging
     
     if (newCount >= 5) {
       setClickCount(0); // Reset counter


### PR DESCRIPTION
## Summary
- remove `console.log` statements from the Home page

## Testing
- `npm test -- --watchAll=false` *(fails: Unable to find learn react link)*

------
https://chatgpt.com/codex/tasks/task_e_6871eab951a0832cbba6d6e7b3c96264